### PR TITLE
Clean up debug artifacts

### DIFF
--- a/guardian-ui/.gitignore
+++ b/guardian-ui/.gitignore
@@ -9,6 +9,9 @@ Thumbs.db
 # Electron
 out/
 
+# Debug dump files
+asar*
+
 # Local Claude Code config (personal, don't commit)
 .claude/settings.local.json
 CLAUDE.local.md


### PR DESCRIPTION
## Summary
- Remove leftover asar debug dump files (asar-contents.txt, asar-contents2.txt, asar3.txt, asar-extract/)
- Add asar* pattern to .gitignore to prevent future accumulation

## Test plan
- [ ] Verify asar files no longer present in repo
- [ ] Confirm .gitignore blocks new asar* files

Co-authored with Opus